### PR TITLE
Remove cname as it is breaking octopub

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-labs.theodi.org


### PR DESCRIPTION
merging this because all ODI owned datasets published on octopub are broken because of this